### PR TITLE
Metric graphs should have minimum height

### DIFF
--- a/www/app/metric-details/metricDetail.js
+++ b/www/app/metric-details/metricDetail.js
@@ -48,7 +48,7 @@ angular
 			var pos = $('.graph').position();
 
 			// Sets height of graph with a minimum of 500px
-			this.height = Math.min(window.innerHeight - pos.top - 100, 500);
+			this.height = Math.max(window.innerHeight - pos.top - 100, 500);
 
 			$scope.$watchCollection('modifier', function(val, old, scope) {
 				if ($routeParams.stat !== val.stat) {

--- a/www/app/metric-details/metricDetail.js
+++ b/www/app/metric-details/metricDetail.js
@@ -48,8 +48,7 @@ angular
 			var pos = $('.graph').position();
 
 			// Sets height of graph with a minimum of 500px
-			var potentialHeight = window.innerHeight - pos.top - 100;
-			this.height = potentialHeight >= 500 ? potentialHeight : '500';
+			this.height = Math.min(window.innerHeight - pos.top - 100, 500);
 
 			$scope.$watchCollection('modifier', function(val, old, scope) {
 				if ($routeParams.stat !== val.stat) {

--- a/www/app/metric-details/metricDetail.js
+++ b/www/app/metric-details/metricDetail.js
@@ -46,7 +46,10 @@ angular
 			};
 
 			var pos = $('.graph').position();
-			this.height = window.innerHeight - pos.top - 100;
+
+			// Sets height of graph with a minimum of 500px
+			var potentialHeight = window.innerHeight - pos.top - 100;
+			this.height = potentialHeight >= 500 ? potentialHeight : '500';
 
 			$scope.$watchCollection('modifier', function(val, old, scope) {
 				if ($routeParams.stat !== val.stat) {


### PR DESCRIPTION
Status: **Ready for Review**
Reviewers: @donnielrt @haroldtreen 
## Changes
- Instead of accepting any value for graph height, pin it at a minimum of 500px so we get something usable on small- or mobile-sized screens
## Todos:
- [x] Engineer +1
### Feedback:

_none so far_
## How to Test
- Ensure you have Apache CouchDB set up locally (see http://couchdb.apache.org/#download)
- Clone this repository and check out this branch
- Run `npm install` and `npm link`
- `cd` into your `adaptive-perf` repository and run `npm link perfjankie`
- Still inside your `adaptive-perf` repository, run `npm link` so you can use your local instance as an npm module
- Modify the settings of `config/perfjankie.js`:

``` javascript
var DEFAULTS = {
    couch: {
        server: 'http://localhost:5984',
        updateSite: true,
        onlyUpdateSite: true
    }
};
```
- Run `ajs-perf perfjankie --url "blah" --slug "thinkgeek-ios" --name "thinkgeek"` (assumes you have prior metrics data stored in your local database)
